### PR TITLE
fix(Modelarts): remove the type of label

### DIFF
--- a/docs/resources/modelarts_dataset.md
+++ b/docs/resources/modelarts_dataset.md
@@ -25,7 +25,6 @@ resource "huaweicloud_modelarts_dataset" "test" {
 
   labels {
     name = "foo"
-    type = 1
   }
 }
 ```

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_test.go
@@ -56,7 +56,6 @@ func TestAccResourceDateset_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data_source.0.data_type", "0"),
 					resource.TestCheckResourceAttr(resourceName, "data_source.0.path", fmt.Sprintf("/%s/%s/", obsName, "input")),
 					resource.TestCheckResourceAttr(resourceName, "labels.0.name", name),
-					resource.TestCheckResourceAttr(resourceName, "labels.0.type", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 				),
 			},
@@ -73,7 +72,6 @@ func TestAccResourceDateset_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data_source.0.data_type", "0"),
 					resource.TestCheckResourceAttr(resourceName, "data_source.0.path", fmt.Sprintf("/%s/%s/", obsName, "input")),
 					resource.TestCheckResourceAttr(resourceName, "labels.0.name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "labels.0.type", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 				),
 			},
@@ -130,7 +128,6 @@ resource "huaweicloud_modelarts_dataset" "test" {
 
   labels {
     name = "%s"
-    type = 1
   }
 
   depends_on = [

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_dataset.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_dataset.go
@@ -67,7 +67,7 @@ func ResourceDataset() *schema.Resource {
 				Optional: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 256),
-					validation.StringMatch(regexp.MustCompile(`^[&<>=!"'/]+$`),
+					validation.StringMatch(regexp.MustCompile(`^[^&<>=!"'/]+$`),
 						"The description contains a maximum of 256 characters, "+
 							"and cannot contain special characters !<>=&\"'."),
 				),
@@ -577,7 +577,6 @@ func setLabelsToState(d *schema.ResourceData, labels []dataset.Label) error {
 	for i, v := range labels {
 		result[i] = map[string]interface{}{
 			"name":              v.Name,
-			"type":              v.Type,
 			"property_color":    v.Property.Color,
 			"property_shape":    v.Property.DefaultShape,
 			"property_shortcut": v.Property.Shortcut,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
remove the type of label 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run=TestAccResourceDateset_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run=TestAccResourceDateset_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDateset_basic
=== PAUSE TestAccResourceDateset_basic
=== CONT  TestAccResourceDateset_basic
--- PASS: TestAccResourceDateset_basic (85.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 85.366s
```
